### PR TITLE
Correct error when passing in UUID to communicate with specific drone

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -20,6 +20,7 @@ var Adaptor = module.exports = function Adaptor(opts) {
 	Adaptor.__super__.constructor.apply(this, arguments);
 
 	this.opts = opts || {};
+	this.uuid = this.opts.uuid || null;
 
 	this.connector = null;
 };
@@ -30,7 +31,7 @@ Adaptor.prototype.connect = function (callback) {
 
 	Cylon.Logger.info('Adaptor#connect');
 
-	this.connector = new RollingSpider({uuid: this.opts.uuid});
+	this.connector = new RollingSpider({uuid: this.uuid});
 
 	this.proxyMethods(Commands, this.connector, this);
 

--- a/spec/lib/adaptor.spec.js
+++ b/spec/lib/adaptor.spec.js
@@ -1,9 +1,40 @@
 'use strict';
 
+var Cylon = require("cylon");
 var RollingSpider = source("adaptor");
 
 describe("Cylon.Adaptors.RollingSpider", function () {
-	var adaptor = new RollingSpider();
+	var adaptor;
 
-	it("needs tests");
+  it("is a subclass of Cylon.Adaptor", function() {
+  	adaptor = new RollingSpider();
+    expect(adaptor).to.be.an.instanceOf(RollingSpider);
+    expect(adaptor).to.be.an.instanceOf(Cylon.Adaptor);
+  });
+
+	describe("when not passed a UUID", function () {
+	  beforeEach(function() {
+	    adaptor = new RollingSpider();
+	  });
+
+	  describe("#constructor", function() {
+	    it("@uuid is null", function() {
+	      expect(adaptor.uuid).to.be.null;
+	    });
+	  });
+	});
+
+	describe("when passed a UUID", function () {
+	  beforeEach(function() {
+	    adaptor = new RollingSpider({
+	      uuid: "uuid",
+	    });
+	  });
+
+	  describe("#constructor", function() {
+	    it("sets @uuid to the provided UUID", function() {
+	      expect(adaptor.uuid).to.be.eql("uuid");
+	    });
+	  });
+	});
 });


### PR DESCRIPTION
The `uuid` parameter was not being correctly handled when connecting to a specific drone. 

This PR fixes that and adds a couple of tests.
