### PR TITLE
make devices match name used in the work function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Cylon.robot({
   },
 
 	devices: {
-    'rolling-spider': { driver: 'rolling-spider' },
+    drone: { driver: 'rolling-spider' },
   }
 
 	work: function (my) {


### PR DESCRIPTION
code sample doesn't actually work due to mismatched names. patch fixes that.
